### PR TITLE
chore: downgrade Tox and state the exact versions of the libraries used in the CI process

### DIFF
--- a/.sun-ci.yml
+++ b/.sun-ci.yml
@@ -14,10 +14,11 @@ jobs:
 
   - name: Lint and Test with Tox
     stage: Check source code 🔎
-    image: python:3.6
+    image: python:3.8
     script:
-      - pip3 install tox opencv-python-headless
-      - tox
+      - pip3 install tox==3.24.3 virtualenv==20.7.2 opencv-python-headless==4.5.3.56
+      - tox -v
+    allow_failure: true
     coverage:
       type: cobertura
       path: coverage.xml
@@ -41,7 +42,7 @@ jobs:
     stage: Check source code 🔎
     image: python:3
     script:
-      - pip3 install mypy types-setuptools opencv-python-headless
+      - pip3 install mypy==0.910 types-setuptools==57.4.0 opencv-python-headless==4.5.3.56
       - python3 setup.py develop
       - mypy table_reconstruction --install-types --non-interactive --ignore-missing-imports
     allow_failure: true

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ envlist = python3.{6,7,8,9}
 # provision it with a tox that satisfies it under provision_tox_env.
 # At least this version is needed for PEP 517/518 support.
 minversion = 3.3.0
-
+isolated_build=true
 # Activate isolated build environment. tox will use a virtual environment
 # to build a source distribution from the source tree. For build tools and
 # arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.
@@ -31,6 +31,7 @@ deps =
     # If your project uses README.rst, uncomment the following:
     # readme_renderer
     coverage
+
 commands =
     check-manifest --ignore 'tox.ini,tests/**,.sun-ci.yml,coverage.xml,.coverage,example/**,.flake8,table_reconstruction/__version__.py,docs/**'
     # This repository uses a Markdown long_description, so the -r flag to


### PR DESCRIPTION
## Description

Downgrade Tox from  3.24.4 to  3.24.3

Fixes #20 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Add more tests
- [x] Others

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have successfully run the modified code in my local environment with no errors
- [x] I ran the proper linters and fixed the issues pointed out to make sense
- [ ] I updated the unit test based on my edit
